### PR TITLE
Add Tauri desktop launcher and unified build scripts

### DIFF
--- a/.env.desktop
+++ b/.env.desktop
@@ -1,0 +1,5 @@
+# Environment settings for the desktop launcher
+# The actual values should be provided by developers before running
+BACKEND_HTTP_URL=
+BACKEND_WS_URL=
+FRONTEND_DEV_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ frontend/src/resources/config.template.js
 frontend/src/resources/config.js
 target
 docker/backend/start_ci.sh
+# Desktop launcher artifacts
+app-launcher/node_modules
+app-launcher/src-tauri/target
+app-launcher/src-tauri/bundle

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: dev build run
+
+# Start backend, frontend dev server and Tauri app
+# Requires environment variables from .env.desktop
+
+dev:
+	./tools/dev.sh
+
+# Build frontend and Tauri bundle
+build:
+	./tools/build.sh
+
+# Run the packaged desktop app
+run:
+	./tools/run.sh

--- a/README.md
+++ b/README.md
@@ -36,3 +36,44 @@ Mempool can be installed in other ways too, but we only recommend doing so if yo
 - See the [`docker/`](./docker/) directory for instructions on deploying Mempool with Docker.
 - See the [`backend/`](./backend/) and [`frontend/`](./frontend/) directories for manual install instructions oriented for developers.
 - See the [`production/`](./production/) directory for guidance on setting up a more serious Mempool instance designed for high performance at scale.
+
+## Desktop launcher
+
+A lightweight desktop wrapper based on [Tauri](https://tauri.app/) is available in the `app-launcher` directory. It embeds the
+web UI in a single window and connects to a running backend.
+
+### Environment
+
+Create a `.env.desktop` file with the following keys:
+
+```
+BACKEND_HTTP_URL=    # Base HTTP URL of the backend API
+BACKEND_WS_URL=      # WebSocket URL for realtime updates
+FRONTEND_DEV_URL=    # Dev server URL used by Tauri in `make dev`
+```
+
+### Development
+
+```
+make dev
+```
+
+This starts the backend, the frontend dev server and the Tauri application.
+
+### Build
+
+```
+make build
+```
+
+Static assets are built and bundled into platform specific installers.
+
+### Run
+
+``` 
+make run
+```
+
+Launches the packaged desktop app. Bundled installers and binaries are
+written to `app-launcher/src-tauri/target/release/bundle/` (e.g. `.dmg`,
+`.msi`, `.AppImage`).

--- a/app-launcher/package.json
+++ b/app-launcher/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mempool-app-launcher",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Tauri launcher for the Mempool web UI",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^2"
+  },
+  "scarfSettings": {
+    "enabled": false
+  }
+}

--- a/app-launcher/src-tauri/Cargo.toml
+++ b/app-launcher/src-tauri/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "app-launcher"
+version = "0.1.0"
+edition = "2021"
+description = "Mempool desktop launcher"
+
+[dependencies]
+tauri = { version = "1", features = ["window", "protocol"] }
+tauri-plugin-single-instance = "0.1"
+tauri-plugin-log = { version = "0.2", features = ["rotation"] }
+tempfile = "3"
+dirs-next = "2"
+serde = { version = "1", features = ["derive"] }
+
+[build-dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/app-launcher/src-tauri/src/main.rs
+++ b/app-launcher/src-tauri/src/main.rs
@@ -1,0 +1,78 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::sync::Mutex;
+use std::{env, fs};
+use tauri::{Manager, WindowEvent, WindowUrl};
+use tempfile::TempDir;
+use tauri_plugin_log::LogTarget;
+
+struct ProfileDir(Mutex<Option<TempDir>>);
+
+fn main() {
+    // create temp profile directory for this run
+    let tmp = TempDir::new().expect("temp dir");
+    let profile_path = tmp.path().to_path_buf();
+    env::set_var("TEMP_PROFILE_DIR", &profile_path);
+
+    tauri::Builder::default()
+        .register_uri_scheme_protocol("app", |app, request| {
+            let path = request
+                .uri()
+                .replace("app://", "")
+                .trim_start_matches('/')
+                .to_string();
+            let asset = app
+                .asset_resolver()
+                .get(&path)
+                .unwrap_or_else(|| app.asset_resolver().get("index.html").unwrap());
+            tauri::http::ResponseBuilder::new()
+                .mimetype(asset.mime_type())
+                .body(asset.bytes().to_vec())
+                .unwrap()
+        })
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .target(LogTarget::LogDir)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+                .build(),
+        )
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            if let Some(window) = app.get_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }))
+        .manage(ProfileDir(Mutex::new(Some(tmp))))
+        .setup(|app| {
+            let url = if cfg!(debug_assertions) {
+                let dev = env::var("FRONTEND_DEV_URL").expect("FRONTEND_DEV_URL");
+                WindowUrl::External(dev.parse().unwrap())
+            } else {
+                WindowUrl::App("index.html".into())
+            };
+            tauri::WindowBuilder::new(app, "main", url)
+                .title("Mempool")
+                .inner_size(1280.0, 800.0)
+                .resizable(true)
+                .initialization_script(r#"document.addEventListener('dragover',e=>e.preventDefault());document.addEventListener('drop',e=>e.preventDefault());"#)
+                .navigation_handler(|url| {
+                    let allowed = ["app://", "http://localhost", "https://localhost"];
+                    allowed.iter().any(|prefix| url.as_str().starts_with(prefix))
+                })
+                .build()?;
+            Ok(())
+        })
+        .on_window_event(|event| {
+            if let WindowEvent::CloseRequested { .. } = event.event() {
+                let handle = event.window().app_handle();
+                let state = handle.state::<ProfileDir>();
+                if let Some(dir) = state.0.lock().unwrap().take() {
+                    let path = dir.into_path();
+                    let _ = fs::remove_dir_all(path);
+                }
+                std::process::exit(0);
+            }
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/app-launcher/src-tauri/tauri.conf.json
+++ b/app-launcher/src-tauri/tauri.conf.json
@@ -1,0 +1,50 @@
+{
+  "package": {
+    "productName": "Mempool Launcher",
+    "version": "0.1.0"
+  },
+  "build": {
+    "devPath": "$env(FRONTEND_DEV_URL)",
+    "distDir": "../frontend/dist/mempool/browser"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Mempool",
+        "width": 1280,
+        "height": 800,
+        "resizable": true,
+        "decorations": true,
+        "fullscreen": false,
+        "devtools": false
+      }
+    ],
+    "singleInstance": {
+      "enabled": true
+    },
+    "security": {
+      "csp": "default-src 'self'; img-src 'self' data https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' $env(BACKEND_HTTP_URL) $env(BACKEND_WS_URL);",
+      "dangerousDisableAssetCspModification": false
+    },
+    "allowlist": {
+      "all": false,
+      "shell": false,
+      "http": false,
+      "open": false
+    },
+    "webview": {
+      "dataDirectory": "$env(TEMP_PROFILE_DIR)"
+    },
+    "protocol": {
+      "custom": {
+        "schemes": ["app"]
+      }
+    },
+    "bundle": {
+      "active": true,
+      "targets": "all",
+      "identifier": "com.mempool.launcher"
+    }
+  }
+}

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -1,0 +1,15 @@
+$Root = Split-Path $MyInvocation.MyCommand.Path -Parent | Split-Path -Parent
+$EnvFile = Join-Path $Root '.env.desktop'
+if (Test-Path $EnvFile) {
+  Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^(\w+)=(.*)$') {
+      $name = $matches[1]
+      $value = $matches[2]
+      if ($value) { Set-Item -Path Env:$name -Value $value }
+    }
+  }
+}
+
+npm --prefix (Join-Path $Root 'frontend') run build
+npm --prefix (Join-Path $Root 'backend') run build
+npm --prefix (Join-Path $Root 'app-launcher') run build

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ -f "$ROOT_DIR/.env.desktop" ]; then
+  set -a
+  source "$ROOT_DIR/.env.desktop"
+  set +a
+fi
+
+npm --prefix "$ROOT_DIR/frontend" run build
+npm --prefix "$ROOT_DIR/backend" run build
+npm --prefix "$ROOT_DIR/app-launcher" run build

--- a/tools/dev.ps1
+++ b/tools/dev.ps1
@@ -1,0 +1,23 @@
+$Root = Split-Path $MyInvocation.MyCommand.Path -Parent | Split-Path -Parent
+$EnvFile = Join-Path $Root '.env.desktop'
+if (Test-Path $EnvFile) {
+  Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^(\w+)=(.*)$') {
+      $name = $matches[1]
+      $value = $matches[2]
+      if ($value) { Set-Item -Path Env:$name -Value $value }
+    }
+  }
+}
+
+# Build backend and start it
+npm --prefix (Join-Path $Root 'backend') run build | Out-Null
+Start-Process npm -ArgumentList @('--prefix', (Join-Path $Root 'backend'), 'run', 'start')
+
+# Start frontend dev server
+Start-Process npm -ArgumentList @('--prefix', (Join-Path $Root 'frontend'), 'run', 'start')
+
+Start-Sleep -Seconds 5
+
+# Launch Tauri dev
+npm --prefix (Join-Path $Root 'app-launcher') run dev

--- a/tools/dev.sh
+++ b/tools/dev.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Load environment variables from .env.desktop if present
+if [ -f "$ROOT_DIR/.env.desktop" ]; then
+  set -a
+  source "$ROOT_DIR/.env.desktop"
+  set +a
+fi
+
+# Build backend and start it in the background
+npm --prefix "$ROOT_DIR/backend" run build >/dev/null 2>&1 && \
+  npm --prefix "$ROOT_DIR/backend" run start &
+disown
+
+# Start frontend dev server in the background
+npm --prefix "$ROOT_DIR/frontend" run start &
+disown
+
+# Give servers a moment to start
+sleep 5
+
+# Launch Tauri app in dev mode
+npm --prefix "$ROOT_DIR/app-launcher" run dev

--- a/tools/run.ps1
+++ b/tools/run.ps1
@@ -1,0 +1,18 @@
+$Root = Split-Path $MyInvocation.MyCommand.Path -Parent | Split-Path -Parent
+$EnvFile = Join-Path $Root '.env.desktop'
+if (Test-Path $EnvFile) {
+  Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^(\w+)=(.*)$') {
+      $name = $matches[1]
+      $value = $matches[2]
+      if ($value) { Set-Item -Path Env:$name -Value $value }
+    }
+  }
+}
+
+$Binary = Join-Path $Root 'app-launcher/src-tauri/target/release/app-launcher.exe'
+if (Test-Path $Binary) {
+  & $Binary @args
+} else {
+  Write-Error 'Built launcher not found. Run make build first.'
+}

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ -f "$ROOT_DIR/.env.desktop" ]; then
+  set -a
+  source "$ROOT_DIR/.env.desktop"
+  set +a
+fi
+
+BINARY="$ROOT_DIR/app-launcher/src-tauri/target/release/app-launcher"
+if [ -f "$BINARY" ]; then
+  "$BINARY" "$@"
+else
+  echo "Built launcher not found. Run make build first." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- document desktop launcher env vars and usage, including packaged app run instructions
- drop CI workflow and placeholder icon

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_b_689a5a5339c083319bcaac719630c44b